### PR TITLE
Update NAP-Belgium metadata access details

### DIFF
--- a/docs/NAP-Belgium.md
+++ b/docs/NAP-Belgium.md
@@ -6,8 +6,21 @@
 
 ## Access metadata
 
-By openining the page of a dataset, it is possible to visualise metadata compliant with mobilityDCAT-AP.
+Following the DCAT model, metadata can be accessed at both individual dataset level and catalog-wide level. MobilityDCAT-AP support for the Transportdata platform is implemented through [ckanext-dcat-be-napits](https://github.com/belgium-its-steering-committee/ckanext-dcat-be-napits), a custom-built extension to the CKAN platform.
+
+### Dataset
+
+Suffix the dataset page url with a common linked data format extension:  
+Example: `https://transportdata.be/dataset/wegenregister.ttl`
+
+### Catalog
+
+Suffix the catalog url with a common linked data format extension:  
+Example: `https://transportdata.be/catalog.ttl`  
+
+
+See the [ckanext-dcat documentation](https://docs.ckan.org/projects/ckanext-dcat/en/latest/endpoints/#dataset-endpoints) for more details on how the url's are composed and what RDF formats are available.
 
 ## Harvest metadata
 
-Documentation not available.
+Development in progress. Documentation not available just yet.


### PR DESCRIPTION
Hi,

Following the development on the Belgian NAP endpoints, hereby we'd like to update the Belgian documentation page in the "adopters" repo with some more details.  
We also [submitted the CKAN extension](https://github.com/napcore-tools/web-awesome_napcore_tools/discussions/22) we developed to the "Awesome NAPCORE Tools Catalog". More technical details on how the endpoints are set up can be found there.

Kind regards,

Michaël Dierick